### PR TITLE
fixed search when not on page 1

### DIFF
--- a/frontend/src/views/Torrents.vue
+++ b/frontend/src/views/Torrents.vue
@@ -83,6 +83,7 @@ export default {
   watch: {
     '$route.query.search': function (search) {
       search ? this.search = search : this.search = '';
+      this.currentPage = 1;
       this.loadTorrents(this.currentPage, this.sorting);
     },
     '$route.params.sorting': function () {


### PR DESCRIPTION
if you navigate to page 2,3 etc and then try use the search it doesn't work. this tiny patch fixes it