### PR TITLE
Allow linking directly to torrent download

### DIFF
--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -29,7 +29,7 @@ const routes = [
                 component: CategoryOverview
             },
             {
-                path: 'torrent/:torrentId/:title?',
+                path: 'torrent/:torrentId/:title?/:download?',
                 name: 'Torrent',
                 component: TorrentDetail
             },

--- a/frontend/src/views/Torrent.vue
+++ b/frontend/src/views/Torrent.vue
@@ -126,17 +126,20 @@ export default {
   },
   mounted() {
     document.body.classList.add("modal-open");
-    this.getTorrent(this.$route.params.torrentId);
+    this.getTorrent(this.$route.params.torrentId, this.$route.params.download === "download" || this.$route.params.title === "download");
   },
   beforeDestroy() {
     document.body.classList.remove("modal-open");
   },
   methods: {
-    getTorrent(torrentId) {
+    getTorrent(torrentId, download) {
       this.loading = true;
       HttpService.get(`/torrent/${torrentId}`, (res) => {
         this.torrent = res.data.data;
         this.loading = false;
+        if(download){
+          this.downloadTorrent();
+        }
         this.updateUrlWithTitle();
       }).catch(() => {
         this.loading = false;


### PR DESCRIPTION
This PR is aimed at making it easier for people to share torrents by allowing links that start the download as soon as the page is loaded. Basically just saves 1 extra click.