### PR TITLE
Improve pagination

### DIFF
--- a/frontend/src/components/Pagination.vue
+++ b/frontend/src/components/Pagination.vue
@@ -49,12 +49,14 @@
               ...
             </span>
           </template>
-<!--          <button v-else v-for="i in 5" :key="i" v-show="i < totalPages"-->
-<!--                  @click="goToPage(i)"-->
-<!--                  :disabled="i === currentPage"-->
-<!--                  class="page-button">-->
-<!--            {{ i }}-->
-<!--          </button>-->
+          <template v-else>
+            <button v-for="i in 5" :key="i"
+                  @click="goToPage(i)"
+                  :disabled="i === currentPage"
+                  class="page-button">
+                  {{ i }}
+            </button>
+          </template>
 
           <template v-if="currentPage > 4 && currentPage < totalPages-3">
             <button v-for="i in 2" :key="currentPage - 3 + i"

--- a/frontend/src/views/Torrents.vue
+++ b/frontend/src/views/Torrents.vue
@@ -11,7 +11,7 @@
 <!--        Filters-->
 <!--      </button>-->
     </div>
-    <TorrentList class="mt-4" v-if="torrents.results.length > 0" :torrents="torrents.results" :sorting="sorting" :update-sorting="updateSorting"/>
+    <TorrentList id="TorrentList" class="mt-4" v-if="torrents.results.length > 0" :torrents="torrents.results" :sorting="sorting" :update-sorting="updateSorting"/>
     <Pagination v-if="torrents.results.length > 0" :current-page.sync="currentPage" :total-pages="totalPages" :total-results="torrents.total" :page-size="pageSize" />
     <div v-else class="py-6 text-slate-400">This category has no results.</div>
   </div>
@@ -94,6 +94,7 @@ export default {
     },
     currentPage(newPage) {
       this.loadTorrents(newPage, this.sorting);
+      document.getElementById("TorrentList").scrollIntoView({behavior: "smooth"});
     },
     categoryFilters() {
       this.loadTorrents(this.currentPage, this.sorting);


### PR DESCRIPTION
This PR fixes the page buttons at the bottom of the torrent list when viewing pages 1-4, along with adding a feature that scrolls to the top of the page when going between pages.